### PR TITLE
Ensure Tmux zoom when presenting

### DIFF
--- a/lib/termnote/pane/helpers.rb
+++ b/lib/termnote/pane/helpers.rb
@@ -1,5 +1,6 @@
 require_relative 'helpers/title'
 require_relative 'helpers/content'
+require_relative 'helpers/tmux'
 
 module TermNote
   module Pane

--- a/lib/termnote/pane/helpers/tmux.rb
+++ b/lib/termnote/pane/helpers/tmux.rb
@@ -1,0 +1,39 @@
+module TermNote
+  class Show
+    module Helpers
+      class Tmux
+        private
+
+        def self.tmux?
+          @@tmux ||= `which tmux` && ENV['TMUX'].length
+        end
+
+        def self.needs_zoom_out
+          `tmux list-panes -F '\#F'`.include? 'Z'
+        end
+
+        def self.needs_zoom_in
+          !self.needs_zoom_out
+        end
+
+        def self.toggle_zoom
+          system('tmux resize-pane -Z')
+        end
+
+        def self.ensure_zoomed_in
+          if self.tmux?
+            system('tmux set status off')
+            self.needs_zoom_in && self.toggle_zoom
+          end
+        end
+
+        def self.ensure_zoomed_out
+          if self.tmux?
+            system('tmux set status on')
+            self.needs_zoom_out && self.toggle_zoom
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/termnote/show.rb
+++ b/lib/termnote/show.rb
@@ -7,6 +7,7 @@ module TermNote
 
     def initialize
       @panes ||= []
+      ObjectSpace.define_finalizer( self, self.class.finalize )
     end
 
     def add(pane)
@@ -28,6 +29,7 @@ module TermNote
     end
 
     def start
+      Helpers::Tmux.ensure_zoomed_in
       @state = true
       while @state
         pane.call $stdout.winsize
@@ -55,6 +57,10 @@ module TermNote
 
     def capture_command
       @command = $stdin.getch
+    end
+
+    def self.finalize
+      proc { Helpers::Tmux.ensure_zoomed_out }
     end
   end
 end


### PR DESCRIPTION
If opened in a tmux pane it zooms in to fill the whole terminal. After presentation ends the pane is zoomed out.